### PR TITLE
RM-273: Change interfaceConfig event from exit to close to fix Linux …

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -142,7 +142,7 @@ export default class Cluster {
           }
         });
 
-        interfaceConfig.once('exit', () => {
+        interfaceConfig.once('close', () => {
           const missingAliases = _.difference(addresses, configuredAliases, ['127.0.0.1']);
           if (!loopbackUp && !_.some(missingAliases)) {
             if (configureLoopbackAliases) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -126,79 +126,89 @@ export default class Cluster {
     const { configureLoopbackAliases } = this.options;
 
     return new Promise((resolve, reject) => {
-      spawn(CHECK_MACHINE_CMD).stdout.on('data', (data) => {
-        const machine = data.toString().trim();
-        const checkInterface = CHECK_INTERFACE_CMD[machine];
-        const interfaceConfig = spawn(checkInterface.cmd, checkInterface.params);
+      const checkMachine = spawn(CHECK_MACHINE_CMD);
 
-        const configuredAliases = [];
-        let loopbackUp = false;
-        interfaceConfig.stdout.pipe(split()).on('data', (line) => {
-          if (line.match(LOOPBACK_IF_UP_REG[machine])) {
-            loopbackUp = true;
-          } else if (line.match(LOOPBACK_ALIAS_REG[machine])) {
-            const [, loopbackAddress] = LOOPBACK_ALIAS_REG[machine].exec(line);
-            configuredAliases.push(loopbackAddress.split('/').shift());
-          }
-        });
-
-        interfaceConfig.once('close', () => {
-          const missingAliases = _.difference(addresses, configuredAliases, ['127.0.0.1']);
-          if (!loopbackUp && !_.some(missingAliases)) {
-            if (configureLoopbackAliases) {
-              this.log(
-                'warning',
-                'Loopback interface down. Bringing it back up will require sudo privileges.'
-              );
-              const loopback = spawn('sudo', UP_LOOPBACK_INTERFACE_CMD[machine]);
-              loopback.on('exit', (code) => {
-                if (code === 0) {
-                  resolve();
-                } else {
-                  reject();
-                }
-              });
-            } else {
-              reject();
-            }
-          } else if (_.some(missingAliases)) {
-            if (configureLoopbackAliases) {
-              this.log(
-                'warning',
-                `Loopback address not configured for [${missingAliases.join(', ')}]. Configuring it will require sudo privileges.`
-              );
-              _.reduce(
-                missingAliases,
-                (p, address) =>
-                  p.then(() => {
-                    const loopback = spawn('sudo', UP_LOOPBACK_ADDR_CMD(machine, address));
-                    return new Promise((resolveLoopback, rejectLoopback) => {
-                      loopback.on('exit', (code) => {
-                        if (code === 0) {
-                          resolveLoopback();
-                        } else {
-                          rejectLoopback();
-                        }
-                      });
-                    });
-                  }),
-                Promise.resolve()
-              ).then(resolve, reject);
-            } else {
-              reject();
-            }
-          } else {
-            resolve();
-          }
-        });
+      checkMachine.stdout.pipe(split()).on('data', (line) => {
+        if (!_.has(CHECK_INTERFACE_CMD, line)) {
+          reject(new Error(`${line} not currently supported`));
+          return;
+        }
+        resolve(line);
       });
-    }).catch(() => {
-      this.log(
-        'error',
-        'Loopback aliases not configured properly. View the README to configure them manually or set `configureLoopbackAliases` to true to configure it automatically. (Requires sudo privileges)'
-      );
-      return Promise.reject(new Error('Loopback aliases not configured'));
-    });
+    })
+      .then(machine =>
+        new Promise((resolve, reject) => {
+          const checkInterface = CHECK_INTERFACE_CMD[machine];
+          const interfaceConfig = spawn(checkInterface.cmd, checkInterface.params);
+
+          const configuredAliases = [];
+          let loopbackUp = false;
+          interfaceConfig.stdout.pipe(split()).on('data', (line) => {
+            if (line.match(LOOPBACK_IF_UP_REG[machine])) {
+              loopbackUp = true;
+            } else if (line.match(LOOPBACK_ALIAS_REG[machine])) {
+              const [, loopbackAddress] = LOOPBACK_ALIAS_REG[machine].exec(line);
+              configuredAliases.push(loopbackAddress.split('/').shift());
+            }
+          });
+
+          interfaceConfig.once('close', () => {
+            const missingAliases = _.difference(addresses, configuredAliases, ['127.0.0.1']);
+            if (!loopbackUp && !_.some(missingAliases)) {
+              if (configureLoopbackAliases) {
+                this.log(
+                  'warning',
+                  'Loopback interface down. Bringing it back up will require sudo privileges.'
+                );
+                const loopback = spawn('sudo', UP_LOOPBACK_INTERFACE_CMD[machine]);
+                loopback.on('close', (code) => {
+                  if (code === 0) {
+                    resolve();
+                  } else {
+                    reject();
+                  }
+                });
+              } else {
+                reject();
+              }
+            } else if (_.some(missingAliases)) {
+              if (configureLoopbackAliases) {
+                this.log(
+                  'warning',
+                  `Loopback address not configured for [${missingAliases.join(', ')}]. Configuring it will require sudo privileges.`
+                );
+                _.reduce(
+                  missingAliases,
+                  (p, address) =>
+                    p.then(() => {
+                      const loopback = spawn('sudo', UP_LOOPBACK_ADDR_CMD(machine, address));
+                      return new Promise((resolveLoopback, rejectLoopback) => {
+                        loopback.on('close', (code) => {
+                          if (code === 0) {
+                            resolveLoopback();
+                          } else {
+                            rejectLoopback();
+                          }
+                        });
+                      });
+                    }),
+                  Promise.resolve()
+                ).then(resolve, reject);
+              } else {
+                reject();
+              }
+            } else {
+              resolve();
+            }
+          });
+        }))
+      .catch(() => {
+        this.log(
+          'error',
+          'Loopback aliases not configured properly. View the README to configure them manually or set `configureLoopbackAliases` to true to configure it automatically. (Requires sudo privileges)'
+        );
+        return Promise.reject(new Error('Loopback aliases not configured'));
+      });
   }
 
   verifyPortOpen() {
@@ -216,7 +226,7 @@ export default class Cluster {
       });
 
       return new Promise((resolve, reject) => {
-        grep.once('exit', () => {
+        grep.once('close', () => {
           if (isOpen) {
             resolve();
           } else {

--- a/test.js
+++ b/test.js
@@ -6,16 +6,17 @@ const cluster = ccm.createCluster({
   clusterConfig: { enable_user_defined_functions: true },
   // configureLoopbackAliases: false,
   nodes: 2,
-  startAddress: '127.0.0.2',
+  startAddress: '127.0.0.4',
   jmxPort: 7101,
   purge: true,
-  version: 3.8,
+  version: 3.8
   // verbose: true,
 });
 
 const timeout = (t = 1000) => new Promise(resolve => setTimeout(resolve, t));
 
-cluster.initialize()
+cluster
+  .initialize()
   // .then(() => timeout())
   .then(() => cluster.populateNodes())
   // .then(() => timeout())
@@ -26,7 +27,7 @@ cluster.initialize()
   .then(() => {
     const rl = readline.createInterface({
       input: process.stdin,
-      output: process.stdout,
+      output: process.stdout
     });
     return new Promise((resolve) => {
       rl.question('Press [r] to remove, [s] to stop, and enter to leave it up... ', (response) => {


### PR DESCRIPTION
…bug.

As we tested the new node-ccm version 0.3.4, the test's still failing because it seems the on('exit') event was being emitted already even the .on('data') event is not yet done. So I debug it directly in the server and tried the on('close') event. This time it work.